### PR TITLE
Fix for #16: Wrong source location is reported

### DIFF
--- a/project/build/SLF4SProject.scala
+++ b/project/build/SLF4SProject.scala
@@ -1,7 +1,7 @@
 import com.weiglewilczek.bnd4sbt._
 import sbt._
 
-class SLF4SProject(info: ProjectInfo) extends DefaultProject(info) with BNDPlugin {
+class SLF4SProject(info: ProjectInfo) extends DefaultProject(info) with BNDPlugin with IdeaProject {
 
   // ===================================================================================================================
   // Dependencies
@@ -50,7 +50,7 @@ class SLF4SProject(info: ProjectInfo) extends DefaultProject(info) with BNDPlugi
   override def bndExportPackage =
     "com.weiglewilczek.slf4s;version=\"%s\"".format(projectVersion.value) :: Nil
   override def bndImportPackage =
-    "org.slf4j;version=\"[1.5,2.0)\"" :: super.bndImportPackage.toList
+    "org.slf4j;version=\"[1.6,2.0)\"" :: "org.slf4j.spi;version=\"[1.6,2.0)\"" ::super.bndImportPackage.toList
   override def bndVersionPolicy = Some("[$(@),$(version;=+;$(@)))")
 
   // ===================================================================================================================

--- a/project/plugins/plugins.scala
+++ b/project/plugins/plugins.scala
@@ -14,4 +14,13 @@ class Plugins(info: ProjectInfo) extends PluginDefinition(info) {
   // ===================================================================================================================
 
   val bnd4sbt = "com.weiglewilczek.bnd4sbt" % "bnd4sbt" % "1.0.1"
+
+
+  // ===================================================================================================================
+  // IDE support
+  // ===================================================================================================================
+
+  val sbtIdeaRepo = "sbt-idea-repo" at "http://mpeltonen.github.com/maven/"
+  val sbtIdea = "com.github.mpeltonen" % "sbt-idea-plugin" % "0.4.0"
+
 }

--- a/src/test/scala/LocationAwareLoggerSpec.scala
+++ b/src/test/scala/LocationAwareLoggerSpec.scala
@@ -1,0 +1,265 @@
+/*
+ * Copyright 2010-2011 Weigle Wilczek GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.weiglewilczek.slf4s
+import org.slf4j.spi.{LocationAwareLogger=>SLF4JLocationAwareLogger}
+import org.slf4j.spi.LocationAwareLogger.{ERROR_INT, WARN_INT, INFO_INT, DEBUG_INT, TRACE_INT}
+import org.specs.Specification
+import org.specs.mock.Mockito
+
+class LocationAwareLoggerSpec extends Specification with Mockito {
+
+  "Calling Logger.error(msg)" should {
+    val (logger, slf4jLogger) = loggers
+    var evaluated = false
+    def msg = {
+      evaluated = true
+      Msg
+    }
+
+    "not call SLF4JLogger.log when error not enabled" in {
+      slf4jLogger.isErrorEnabled returns false
+      logger error msg
+      there was no(slf4jLogger).log(null, FQCN, ERROR_INT, Msg, null, null)
+      evaluated mustBe false
+    }
+
+    "call SLF4JLogger.log when error enabled" in {
+      slf4jLogger.isErrorEnabled returns true
+      logger error msg
+      there was one(slf4jLogger).log(null, FQCN, ERROR_INT, Msg, null, null)
+      evaluated mustBe true
+    }
+  }
+
+  "Calling Logger.error(msg, t)" should {
+    val (logger, slf4jLogger) = loggers
+    var evaluated = false
+    def msg = {
+      evaluated = true
+      Msg
+    }
+
+    "not call SLF4JLogger.log when error not enabled" in {
+      slf4jLogger.isErrorEnabled returns false
+      logger.error(msg, t)
+      there was no(slf4jLogger).log(null, FQCN, ERROR_INT, Msg, null, t)
+      evaluated mustBe false
+    }
+
+    "call SLF4JLogger.log when error enabled" in {
+      slf4jLogger.isErrorEnabled returns true
+      logger.error(msg, t)
+      there was one(slf4jLogger).log(null, FQCN, ERROR_INT, Msg, null, t)
+      evaluated mustBe true
+    }
+  }
+
+  "Calling Logger.warn(msg)" should {
+    val (logger, slf4jLogger) = loggers
+    var evaluated = false
+    def msg = {
+      evaluated = true
+      Msg
+    }
+
+    "not call SLF4JLogger.log when warn not enabled" in {
+      slf4jLogger.isWarnEnabled returns false
+      logger warn msg
+      there was no(slf4jLogger).log(null, FQCN, WARN_INT, Msg, null, null)
+      evaluated mustBe false
+    }
+
+    "call SLF4JLogger.log when warn enabled" in {
+      slf4jLogger.isWarnEnabled returns true
+      logger warn msg
+      there was one(slf4jLogger).log(null, FQCN, WARN_INT, Msg, null, null)
+      evaluated mustBe true
+    }
+  }
+
+  "Calling Logger.warn(msg, t)" should {
+    val (logger, slf4jLogger) = loggers
+    var evaluated = false
+    def msg = {
+      evaluated = true
+      Msg
+    }
+
+    "not call SLF4JLogger.log when warn not enabled" in {
+      slf4jLogger.isErrorEnabled returns false
+      logger.warn(msg, t)
+      there was no(slf4jLogger).log(null, FQCN, WARN_INT, Msg, null, t)
+      evaluated mustBe false
+    }
+
+    "call SLF4JLogger.log when warn enabled" in {
+      slf4jLogger.isWarnEnabled returns true
+      logger.warn(msg, t)
+      there was one(slf4jLogger).log(null, FQCN, WARN_INT, Msg, null, t)
+      evaluated mustBe true
+    }
+  }
+
+  "Calling Logger.info(msg)" should {
+    val (logger, slf4jLogger) = loggers
+    var evaluated = false
+    def msg = {
+      evaluated = true
+      Msg
+    }
+
+    "not call SLF4JLogger.log when info not enabled" in {
+      slf4jLogger.isInfoEnabled returns false
+      logger info msg
+      there was no(slf4jLogger).log(null, FQCN, INFO_INT, Msg, null, null)
+      evaluated mustBe false
+    }
+
+    "call SLF4JLogger.log when info enabled" in {
+      slf4jLogger.isInfoEnabled returns true
+      logger info msg
+      there was one(slf4jLogger).log(null, FQCN, INFO_INT, Msg, null, null)
+      evaluated mustBe true
+    }
+  }
+
+  "Calling Logger.info(msg, t)" should {
+    val (logger, slf4jLogger) = loggers
+    var evaluated = false
+    def msg = {
+      evaluated = true
+      Msg
+    }
+
+    "not call SLF4JLogger.log when info not enabled" in {
+      slf4jLogger.isInfoEnabled returns false
+      logger.info(msg, t)
+      there was no(slf4jLogger).log(null, FQCN, INFO_INT, Msg, null, t)
+      evaluated mustBe false
+    }
+
+    "call SLF4JLogger.log when info enabled" in {
+      slf4jLogger.isInfoEnabled returns true
+      logger.info(msg, t)
+      there was one(slf4jLogger).log(null, FQCN, INFO_INT, Msg, null, t)
+      evaluated mustBe true
+    }
+  }
+
+  "Calling Logger.debug(msg)" should {
+    val (logger, slf4jLogger) = loggers
+    var evaluated = false
+    def msg = {
+      evaluated = true
+      Msg
+    }
+
+    "not call SLF4JLogger.log when debug not enabled" in {
+      slf4jLogger.isDebugEnabled returns false
+      logger debug msg
+      there was no(slf4jLogger).log(null, FQCN, DEBUG_INT, Msg, null, null)
+      evaluated mustBe false
+    }
+
+    "call SLF4JLogger.log when debug enabled" in {
+      slf4jLogger.isDebugEnabled returns true
+      logger debug msg
+      there was one(slf4jLogger).log(null, FQCN, DEBUG_INT, Msg, null, null)
+      evaluated mustBe true
+    }
+  }
+
+  "Calling Logger.debug(msg ,t)" should {
+    val (logger, slf4jLogger) = loggers
+    var evaluated = false
+    def msg = {
+      evaluated = true
+      Msg
+    }
+
+    "not call SLF4JLogger.log when debug not enabled" in {
+      slf4jLogger.isDebugEnabled returns false
+      logger.debug(msg, t)
+      there was no(slf4jLogger).log(null, FQCN, DEBUG_INT, Msg, null, t)
+      evaluated mustBe false
+    }
+
+    "call SLF4JLogger.log when debug enabled" in {
+      slf4jLogger.isDebugEnabled returns true
+      logger.debug(msg, t)
+      there was one(slf4jLogger).log(null, FQCN, DEBUG_INT, Msg, null, t)
+      evaluated mustBe true
+    }
+  }
+
+  "Calling Logger.trace(msg)" should {
+    val (logger, slf4jLogger) = loggers
+    var evaluated = false
+    def msg = {
+      evaluated = true
+      Msg
+    }
+
+    "not call SLF4JLogger.log when trace not enabled" in {
+      slf4jLogger.isTraceEnabled returns false
+      logger trace msg
+      there was no(slf4jLogger).log(null, FQCN, TRACE_INT, Msg, null, null)
+      evaluated mustBe false
+    }
+
+    "call SLF4JLogger.log when trace enabled" in {
+      slf4jLogger.isTraceEnabled returns true
+      logger trace msg
+      there was one(slf4jLogger).log(null, FQCN, TRACE_INT, Msg, null, null)
+      evaluated mustBe true
+    }
+  }
+
+  "Calling Logger.trace(msg, t)" should {
+    val (logger, slf4jLogger) = loggers
+    var evaluated = false
+    def msg = {
+      evaluated = true
+      Msg
+    }
+
+    "not call SLF4JLogger.log when trace not enabled" in {
+      slf4jLogger.isTraceEnabled returns false
+      logger.trace(msg, t)
+      there was no(slf4jLogger).log(null, FQCN, TRACE_INT, Msg, null, t)
+      evaluated mustBe false
+    }
+
+    "call SLF4JLogger.log when trace enabled" in {
+      slf4jLogger.isTraceEnabled returns true
+      logger.trace(msg, t)
+      there was one(slf4jLogger).log(null, FQCN, TRACE_INT, Msg, null, t)
+      evaluated mustBe true
+    }
+  }
+
+  private lazy val Msg = "MESSAGE"
+
+  private lazy val t = new Throwable
+
+  private lazy val FQCN = classOf[DefaultLocationAwareLogger].getName
+
+  private def loggers = {
+    val mockSLF4JLogger = mock[SLF4JLocationAwareLogger]
+    val logger = Logger(mockSLF4JLogger)
+    (logger, mockSLF4JLogger)
+  }
+}


### PR DESCRIPTION
Hello Heiko,
this is a fix for the wrong source location shown in log4j and java.util.logging, for example.

With the fix the following code 
    def main(args: Array[String]) {
      val logger = Logger("Main")
      logger.info("This is Main.", new Exception("Just a test."))
    }

produces

```
24.03.2011 20:59:50 foo.Main$ main
INFO: This is Main.
java.lang.Exception: Just a test.
    at foo.Main$.main(Main.scala:12)
    at foo.Main.main(Main.scala)
```

instead of the original

```
24.03.2011 20:25:44 com.weiglewilczek.slf4s.Logger$class info
INFO: This is Main.
java.lang.Exception: Just a test.
    at foo.Main$.main(Main.scala:12)
    at foo.Main.main(Main.scala)
```

Potential problem: This requires slf4j 1.6.x, see the BND definitions. Maybe you want to change the minor of slf4s.

Furthermore I've added the idea plugin for sbt. You might want to revert that part of the change.

Regards,
Martin.
