### PR TITLE
Compile for Scala 2.10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,10 +8,10 @@ version := "1.0.7"
 scalaVersion := "2.9.1"
 
 crossScalaVersions := Seq(
-    "2.8.0",
     "2.8.1",
     "2.9.0-1",
-    "2.9.1")
+    "2.9.1",
+    "2.10.2")
 
 libraryDependencies ++= Seq(
     "org.slf4j" % "slf4j-api" % "1.6.1")


### PR DESCRIPTION
Produces binaries to work with Scala 2.10.2. This should suffice for all 2.10 releases (see http://stackoverflow.com/a/14010015/109942).

BTW cross-compiling 2.8.0 fails with a more recent version of sbt (tested with 0.12.4), hence I removed it.
